### PR TITLE
Rebalance More Mechanoids Assaulter weapon ammunition type

### DIFF
--- a/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
+++ b/Patches/MoreMechanoids/ThingDefs_Misc/Weapons_Mechanoid.xml
@@ -21,19 +21,19 @@
 				  <recoilAmount>1.28</recoilAmount>
 				  <verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				  <hasStandardCommand>true</hasStandardCommand>
-				  <defaultProjectile>Bullet_5x35mmCharged</defaultProjectile>
+				  <defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
 				  <warmupTime>1.1</warmupTime>
 				  <range>86</range>
 				  <ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 				  <burstShotCount>80</burstShotCount>
-				  <soundCast>ChargeLance_Fire</soundCast>
-				  <soundCastTail>GunTail_Heavy</soundCastTail>
+				  <soundCast>Shot_ChargeRifle</soundCast>
+				  <soundCastTail>GunTail_Light</soundCastTail>
 				  <muzzleFlashScale>9</muzzleFlashScale>
 				</Properties>
 				<AmmoUser>
 				  <magazineSize>300</magazineSize>
 				  <reloadTime>9.2</reloadTime>
-				  <ammoSet>AmmoSet_5x35mmCharged</ammoSet>
+				  <ammoSet>AmmoSet_6x18mmCharged</ammoSet>
 				</AmmoUser>
 				<FireModes>
 				  <aimedBurstShotCount>20</aimedBurstShotCount>


### PR DESCRIPTION
Rebalance Assaulter weapon to use 6x18mm charged instead. Firing 5x35mm charged, the same ammunition used by Lancers, meant for 1 shot kills but in full auto and  in the same chassis size as them and superior armor, is not balanced.